### PR TITLE
Add a new option to kill process

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,17 @@ This plugin provides a dummy source to execute arbitrary command when scene is s
 
 ## Current Features
 
-* Execute command at following events.
-  * Show (the scene is shown in either preview or program)
-  * Hide (the scene is hidden so that no longer shown in neither preview nor program)
-  * Activate (the scene goes to the program)
-  * Deactivate (the scene goes from the program)
-  * Show in preview (the scene goes to the preview)
-  * Hide from preview (the scene goes from the preview)
+* Start a command at following events.
+  * Show (the source is shown in either preview or program)
+  * Hide (the source is hidden so that no longer shown in neither preview nor program)
+  * Activate (the source goes to the program)
+  * Deactivate (the source goes from the program)
+  * Show in preview (the source goes to the preview)
+  * Hide from preview (the source goes from the preview)
+* Optionally, kill the created process at these conditions. This feature is not available for Windows as of now.
+  * When hiding, kill the process created at shown.
+  * When deactivating, kill the process created at activated.
+  * When hiding from the preview, kill the process created at preview.
 
 ## Possible Usage
 

--- a/data/locale/en-US.ini
+++ b/data/locale/en-US.ini
@@ -1,1 +1,5 @@
 execute-command="Execute Command"
+prop-sig-show="Send signal to the command at shown when hiding"
+prop-sig-active="Send signal to the command at activated when deactivating"
+prop-sig-preview="Send signal to the command at preview when hiding from preview"
+prop-sig="Signal"


### PR DESCRIPTION
In a usecase that creates a process to control the scene or something during the scene is active, it is useful to kill the process after the scene was deactivated so that the process is no longer alive when the scene is not active. Also added the similar options to preview and shown commands.

The new property dialog is as below.
![obs-cmd-src-signal-props](https://user-images.githubusercontent.com/780600/136536475-4a446069-1e3e-4eee-82b7-f535433150b0.png)

<!-- If unsure, feel free to let them unchecked. -->
- [ ] The commit is reviewed by yourself.
- [ ] The code is tested.
- [ ] Document is up to date or not necessary to be changed.
- [ ] The commit is compatible with repository's license.
