### PR TITLE
Add _exit if exec has failed

### DIFF
--- a/obs-command-source.c
+++ b/obs-command-source.c
@@ -95,6 +95,7 @@ static void fork_exec(const char *cmd, struct command_source *s,
 		setenv_int("OBS_TRANSITION_DURATION", obs_frontend_get_transition_duration());
 
 		execl("/bin/sh", "sh", "-c", cmd, (char *)NULL);
+		_exit(1);
 	}
 	else if (pid != -1) {
 		if (pid_sig) {


### PR DESCRIPTION
### Description
<!--- Describe what was changed, why the change is required, what problem to be solved. -->

Add `_exit` after `execl` to ensure the subprocess can quit even if the `execl` has failed.

I remembered `_exit` is missing when reviewing https://github.com/obsproject/obs-studio/commit/615728fa3be71e928842285ce3ba8f7133d1ad22.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If something is not checked, please also describe it. -->

Not tested.

<!-- If unsure, feel free to let them unchecked. -->
### General checklist
- [ ] The commit is reviewed by yourself.
- [ ] The code is tested.
- [ ] Document is up to date or not necessary to be changed.
- [ ] The commit is compatible with repository's license.
