### PR TITLE
Add OUT OF TREE building

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,18 @@ if(APPLE)
 	set(MACOSX_PLUGIN_SHORT_VERSION_STRING "1")
 endif()
 
+if(BUILD_OUT_OF_TREE)
+	if(NOT LIB_OUT_DIR)
+	    set(LIB_OUT_DIR "/lib/obs-plugins")
+	endif()
+	if(NOT DATA_OUT_DIR)
+	    set(DATA_OUT_DIR "/share/obs/obs-plugins/${PROJECT_NAME}")
+	endif()
+	set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "")
+	install(TARGETS ${PROJECT_NAME} LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/${LIB_OUT_DIR})
+	install(DIRECTORY data/locale DESTINATION ${CMAKE_INSTALL_PREFIX}/${DATA_OUT_DIR})
+endif()
+
 setup_plugin_target(${CMAKE_PROJECT_NAME})
 
 configure_file(installer/installer-macOS.pkgproj.in installer-macOS.generated.pkgproj)


### PR DESCRIPTION
### Description

This is needed to build the plugin using libobs-dev only, not inside the obs-studio. Several plugins are providing out of tree building, and this is very important for Linux distributions because we need to pass some special destinations to the build system when packaging a source code.

### How Has This Been Tested?
These changes were tested over Debian Sid because I intend to package the plugin to send to Debian.

### General checklist
- [x] The commit is reviewed by yourself.
- [x] The code is tested.
- [ ] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.
