### PR TITLE
Set PGID for subprocess and kill by PGID instead of by PID

### DIFF
--- a/obs-command-source.c
+++ b/obs-command-source.c
@@ -108,6 +108,8 @@ static void fork_exec(const char *cmd, struct command_source *s,
 
 	pid_t pid = fork();
 	if (!pid) {
+		pid_t mypid = getpid();
+		setpgid(mypid, mypid);
 		setenv_if("OBS_CURRENT_SCENE", obs_source_get_name(current_src));
 		setenv_if("OBS_PREVIEW_SCENE", obs_source_get_name(preview_src));
 		setenv_if("OBS_SOURCE_NAME", obs_source_get_name(s->self));
@@ -150,8 +152,8 @@ static void cmdsrc_show(void *data)
 #ifndef _WIN32
 static void cmdsrc_kill(const struct command_source *s, pid_t pid, int sig)
 {
-	blog(LOG_DEBUG, "source '%s' sending signal %d to PID %d", obs_source_get_name(s->self), sig, pid);
-	kill(pid, sig);
+	blog(LOG_DEBUG, "source '%s' sending signal %d to PGID %d", obs_source_get_name(s->self), sig, pid);
+	killpg(pid, sig);
 }
 #endif
 


### PR DESCRIPTION
### Description
<!--- Describe what was changed, why the change is required, what problem to be solved. -->

- Set PGID for a newly created process.
- Send signal to processed by the PGID instead of by the PID.

### Motivation

Sometimes shell creates a subprocess instead of just do exec. In that case, the signal does not reach to the actual process and the process won't be terminated. [#22]

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If something is not checked, please also describe it. -->

See a comment below for the reproducing steps.
- https://github.com/norihiro/obs-command-source/issues/22#issuecomment-1465445877

<!-- If unsure, feel free to let them unchecked. -->
### General checklist
- [x] The commit is reviewed by yourself.
- [x] The code is tested.
- [x] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.
