### PR TITLE
Define _GNU_SOURCE at the top

### DIFF
--- a/obs-command-source.c
+++ b/obs-command-source.c
@@ -17,6 +17,10 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
  */
 
+#if !defined(_WIN32) && !defined(__APPLE__)
+#define _GNU_SOURCE // close_range for Linux
+#endif
+
 #include <obs-module.h>
 #include <obs-frontend-api.h>
 #include <util/platform.h>
@@ -26,8 +30,6 @@
 #else
 #ifdef __APPLE__
 #include <libproc.h>
-#else             // Linux
-#define __USE_GNU // close_range
 #endif
 #include <sys/stat.h>
 #include <sys/wait.h>


### PR DESCRIPTION
### Description
<!--- Describe what was changed, why the change is required, what problem to be solved. -->

It is recommended to define `_GNU_SOURCE` at the top of the file instead of defining `__USE_GNU`.

- [Macro: `_GNU_SOURCE`](https://www.gnu.org/software/libc/manual/html_node/Feature-Test-Macros.html#index-_005fGNU_005fSOURCE)
- https://stackoverflow.com/questions/7296963/gnu-source-and-use-gnu

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If something is not checked, please also describe it. -->

Checked the build passed on Fedora 38.

<!-- If unsure, feel free to let them unchecked. -->
### General checklist
- [x] The commit is reviewed by yourself.
- [x] The code is tested.
- [x] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.
