### PR TITLE
.github(Fedora): Remove RPM Fusion repository

### DIFF
--- a/.github/containers/fedora-template/Dockerfile
+++ b/.github/containers/fedora-template/Dockerfile
@@ -1,9 +1,6 @@
 FROM fedora:%releasever%
 
 RUN dnf install -y rpm-build python3-dnf-plugins-core && dnf clean all
-
-# https://docs.fedoraproject.org/en-US/quick-docs/setup_rpmfusion/
-RUN dnf install -y https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm && dnf clean all
 RUN dnf install -y obs-studio obs-studio-devel && dnf clean all
 
 RUN useradd -s /bin/bash -m rpm


### PR DESCRIPTION

### Description
<!--- Describe what was changed, why the change is required, what problem to be solved. -->

Now the latest obs-studio is available from Fedora Project. It is not necessary to install obs-studio from RPM Fusion.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If something is not checked, please also describe it. -->

CI will test it.

<!-- If unsure, feel free to let them unchecked. -->
### General checklist
- [x] The commit is reviewed by yourself.
- [x] The code is tested.
- [x] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.
